### PR TITLE
Fix completion for scoped variables

### DIFF
--- a/autoload/coc/source/neco.vim
+++ b/autoload/coc/source/neco.vim
@@ -10,7 +10,7 @@ function! coc#source#neco#should_complete(opt) abort
   if !get(g:, 'loaded_necovim', 0) | return 0 | endif
   let ch = a:opt['line'][a:opt['col'] - 1]
   if ch ==# '"' || ch ==# "'" | return 0 | endif
-  let synName = synIDattr(synID(a:opt['linenr'],a:opt['colnr'],1),"name")
+  let synName = synIDattr(synID(a:opt['linenr'],a:opt['colnr'],1), 'name')
   if synName ==# 'vimString' || synName ==# 'vimLineComment' | return 0 | endif
   return 1
 endfunction
@@ -20,6 +20,8 @@ function! coc#source#neco#get_startcol(opt) abort
   let part = colnr == 1 ? '' : a:opt['line'][0:colnr-2]
   let col = necovim#get_complete_position(part)
   let ch = a:opt['line'][col + 1]
+  " Tell coc that we're going to start matching after the colon, even though
+  " it's a lie. We'll fix this down below.
   if ch ==# ':'
     return col + 2
   endif
@@ -28,19 +30,23 @@ endfunction
 
 function! coc#source#neco#complete(opt, cb) abort
   let colnr = a:opt['colnr']
-  let input = a:opt['input']
   let part = a:opt['line'][0:colnr - 2]
   let changed = get(a:opt, 'changed', 0)
   if changed < 0
     let changed = 0
   endif
+
+  " Get the complete position again in the case where we're prefixed by 
+  let col = necovim#get_complete_position(part)
+  let input = a:opt['line'][col :]
+
   let items = necovim#gather_candidates(part, input)
   call a:cb(s:Filter(input, items, changed))
 endfunction
 
 function! s:Filter(input, items, index)
   let ch = a:input[a:index]
-  let colon = a:input =~# '\v^(g|l|s):'
+  let colon = a:input =~# '\v^[bwtglsav]:'
   let res = []
   for item in a:items
     let word = item['word']


### PR DESCRIPTION
Completion for all scoped variables wasn't working. The issue is that
necovim expects the completion to start with the scope rather than the
variable name. However, coc needs just the variable name so that it
doesn't filter out the results.

This isn't great, since we're calling necovim#get_complete_position
twice and we're ignoring the input passed to coc#source#neco#complete,
but it does work.

In addition, s:Filter wasn't handling most variable scopes correctly. I
think that script scoped variables are still broken.

-----

The above is from @hoov's commit. An example of the issue is this:
1. Create an environment variable `export MyEnvVar="Hi"`
2. open [n]vim
3. Create a vim variable `let g:MyVimVariable='Bye'`

Current result: Neither are available in completion.
With @hoov's change: they are available as expected.

I'm unsure if it's ok that I'm submitting a PR of someone elses change, but I had no way of submitting an issue on @hoov's fork or otherwise talking with them about it, and I wanted to be sure that @neoclide and the coc community were aware of the issue/potential fix.

